### PR TITLE
ci: add Java 17 and 21 testing matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,10 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    
+    strategy:
+      matrix:
+        java-version: [11, 17, 21]
 
     steps:
       - uses: actions/checkout@v4
@@ -25,10 +29,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      - name: Set up JDK 11
+      - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v4
         with:
-          java-version: '11'
+          java-version: '${{ matrix.java-version }}'
           distribution: 'temurin'
 
       - name: Grant execute permission for gradlew


### PR DESCRIPTION
## Summary
- Add Java 17 and 21 to GitHub Actions testing matrix
- Ensure compatibility across multiple Java versions
- Current JDK 11 target should work on newer versions

## Test plan
- [x] GitHub Actions will test on Java 11, 17, and 21
- [x] Existing tests should pass on all versions

🤖 Generated with [Claude Code](https://claude.ai/code)