### PR TITLE
build: fix JVM target compatibility with toolchain

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,9 +40,14 @@ publishing {
     }
 }
 
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(11))
+    }
+}
+
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
     kotlinOptions {
-        jvmTarget = "11" // Target JVM 11
         languageVersion = "1.7" // Ensure compatibility with Kotlin 1.7 features
         apiVersion = "1.7" // Use the Kotlin 1.7 API
     }


### PR DESCRIPTION
## Summary
- Use Java toolchain to resolve JVM target compatibility warnings
- Fixes warnings between compileJava and compileKotlin tasks
- Ensures consistent JVM target across all compile tasks

## Test plan
- [x] Build should complete without JVM target compatibility warnings
- [x] Tests should continue to pass on all Java versions

🤖 Generated with [Claude Code](https://claude.ai/code)