### PR TITLE
chore: update Gradle to 8.14.3

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Summary
- Update Gradle from 7.2 to 8.14.3
- Resolves JVM target compatibility warnings
- Brings latest Gradle features and bug fixes

## Test plan
- [x] Build succeeds with Gradle 8.14.3
- [x] All existing tests pass
- [x] CI tests on Java 11, 17, and 21

🤖 Generated with [Claude Code](https://claude.ai/code)