### PR TITLE
chore: update Kotlin to 2.2.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@
 
 plugins {
     // Apply the Kotlin JVM plugin to add support for Kotlin on the JVM
-    id("org.jetbrains.kotlin.jvm") version "1.9.23"
+    id("org.jetbrains.kotlin.jvm") version "2.2.0"
     id("maven-publish")
 }
 
@@ -47,8 +47,8 @@ java {
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
-    kotlinOptions {
-        languageVersion = "1.7" // Ensure compatibility with Kotlin 1.7 features
-        apiVersion = "1.7" // Use the Kotlin 1.7 API
+    compilerOptions {
+        languageVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_1_9)
+        apiVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_1_9)
     }
 }


### PR DESCRIPTION
## Summary
- Update from Kotlin 1.9.23 to 2.2.0
- Migrate from deprecated `kotlinOptions` to `compilerOptions` DSL
- Update language version from 1.7 to 1.9 (minimum supported in Kotlin 2.2.0)
- Maintain JDK 11 compatibility for library usage

## Breaking Changes Fixed
- `kotlinOptions` DSL deprecated → migrated to `compilerOptions`
- Kotlin 1.7 language version removed → updated to 1.9

## Test plan
- [x] Build succeeds with Kotlin 2.2.0
- [x] All tests pass
- [x] K2 compiler performance improvements
- [x] Maintains JDK 11 compatibility

🤖 Generated with [Claude Code](https://claude.ai/code)