### PR TITLE
fix(detekt): remove FunctionReturnTypeSpacing violations

### DIFF
--- a/config/baseline.xml
+++ b/config/baseline.xml
@@ -2,12 +2,12 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
-    <ID>CyclomaticComplexMethod:NumberForVietnamese.kt$fun withoutPrefix(hundredsPosition: Int, tensPosition: Int, onesPosition: Int) : String?</ID>
+    <ID>CyclomaticComplexMethod:NumberForVietnamese.kt$fun withoutPrefix(hundredsPosition: Int, tensPosition: Int, onesPosition: Int): String?</ID>
     <ID>MagicNumber:NumberForVietnamese.kt$5</ID>
     <ID>MagicNumber:NumberForVietnamese.kt$9</ID>
     <ID>MagicNumber:NumberForVietnamese.kt$NumberForVietnamese$3</ID>
     <ID>MagicNumber:NumberToPositions.kt$10</ID>
-    <ID>SpacingBetweenFunctionNameAndOpeningParenthesis:NumberToPositions.kt$@Throws(NotImplementedError::class) fun numberToPositions (num: Int) : IntArray</ID>
+    <ID>SpacingBetweenFunctionNameAndOpeningParenthesis:NumberToPositions.kt$@Throws(NotImplementedError::class) fun numberToPositions(num: Int): IntArray</ID>
     <ID>SpreadOperator:NumberToPositions.kt$(*numberToPositions(quot), rem)</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/config/baseline.xml
+++ b/config/baseline.xml
@@ -3,11 +3,6 @@
   <ManuallySuppressedIssues/>
   <CurrentIssues>
     <ID>CyclomaticComplexMethod:NumberForVietnamese.kt$fun withoutPrefix(hundredsPosition: Int, tensPosition: Int, onesPosition: Int) : String?</ID>
-    <ID>FunctionReturnTypeSpacing:NumberForVietnamese.kt$NumberForVietnamese$@Throws(NotImplementedError::class) fun toVietnamese() : String</ID>
-    <ID>FunctionReturnTypeSpacing:NumberForVietnamese.kt$NumberForVietnamese.Companion$fun from(num : Int) : NumberForVietnamese</ID>
-    <ID>FunctionReturnTypeSpacing:NumberForVietnamese.kt$fun withoutPrefix(hundredsPosition: Int, tensPosition: Int, onesPosition: Int) : String?</ID>
-    <ID>FunctionReturnTypeSpacing:NumberToPositions.kt$@Throws(NotImplementedError::class) fun numberToPositions (num: Int) : IntArray</ID>
-    <ID>FunctionReturnTypeSpacing:NumberToVietnamese.kt$@Throws(NotImplementedError::class) fun numberToVietnamese(num: Int) : String</ID>
     <ID>MagicNumber:NumberForVietnamese.kt$5</ID>
     <ID>MagicNumber:NumberForVietnamese.kt$9</ID>
     <ID>MagicNumber:NumberForVietnamese.kt$NumberForVietnamese$3</ID>

--- a/src/main/kotlin/jp/sane/numbertovietnamese/NumberForVietnamese.kt
+++ b/src/main/kotlin/jp/sane/numbertovietnamese/NumberForVietnamese.kt
@@ -2,13 +2,13 @@ package jp.sane.numbertovietnamese
 
 class NumberForVietnamese(val nums: IntArray) {
     companion object {
-        fun from(num : Int) : NumberForVietnamese {
+        fun from(num: Int): NumberForVietnamese {
             return NumberForVietnamese(numberToPositions(num))
         }
     }
 
     @Throws(NotImplementedError::class)
-    fun toVietnamese() : String {
+    fun toVietnamese(): String {
         val normalNumbers = arrayOf(
                 "không", "một", "hai", "ba", "bốn",
                 "năm", "sáu", "bảy", "tám", "chín"
@@ -28,7 +28,7 @@ class NumberForVietnamese(val nums: IntArray) {
     }
 }
 
-fun withoutPrefix(hundredsPosition: Int, tensPosition: Int, onesPosition: Int) : String? {
+fun withoutPrefix(hundredsPosition: Int, tensPosition: Int, onesPosition: Int): String? {
     if (hundredsPosition == 0 && tensPosition == 0 && onesPosition == 0) {
         return null
     }

--- a/src/main/kotlin/jp/sane/numbertovietnamese/NumberToPositions.kt
+++ b/src/main/kotlin/jp/sane/numbertovietnamese/NumberToPositions.kt
@@ -1,7 +1,7 @@
 package jp.sane.numbertovietnamese
 
 @Throws(NotImplementedError::class)
-fun numberToPositions (num: Int) : IntArray {
+fun numberToPositions(num: Int): IntArray {
     if ( num < 0 ) {
         throw NotImplementedError("unknown: $num")
     }

--- a/src/main/kotlin/jp/sane/numbertovietnamese/NumberToVietnamese.kt
+++ b/src/main/kotlin/jp/sane/numbertovietnamese/NumberToVietnamese.kt
@@ -1,6 +1,6 @@
 package jp.sane.numbertovietnamese
 
 @Throws(NotImplementedError::class)
-fun numberToVietnamese(num: Int) : String {
+fun numberToVietnamese(num: Int): String {
     return NumberForVietnamese.from(num).toVietnamese()
 }


### PR DESCRIPTION
## Summary
- Fixed all FunctionReturnTypeSpacing detekt rule violations by removing extra spaces before return type colons
- Updated baseline.xml to remove fixed issues

## Changes
- NumberToVietnamese.kt: Fixed function return type spacing
- NumberForVietnamese.kt: Fixed function return type spacing in multiple functions
- NumberToPositions.kt: Fixed function return type spacing
- config/baseline.xml: Removed fixed FunctionReturnTypeSpacing entries

## Test plan
- [x] Run detekt to verify no FunctionReturnTypeSpacing violations remain
- [x] Run existing tests to ensure functionality is preserved

🤖 Generated with [Claude Code](https://claude.ai/code)