### PR TITLE
chore: clean up baseline.xml by removing fixed SpacingBetweenFunctionNameAndOpeningParenthesis

### DIFF
--- a/config/baseline.xml
+++ b/config/baseline.xml
@@ -7,7 +7,6 @@
     <ID>MagicNumber:NumberForVietnamese.kt$9</ID>
     <ID>MagicNumber:NumberForVietnamese.kt$NumberForVietnamese$3</ID>
     <ID>MagicNumber:NumberToPositions.kt$10</ID>
-    <ID>SpacingBetweenFunctionNameAndOpeningParenthesis:NumberToPositions.kt$@Throws(NotImplementedError::class) fun numberToPositions(num: Int): IntArray</ID>
     <ID>SpreadOperator:NumberToPositions.kt$(*numberToPositions(quot), rem)</ID>
   </CurrentIssues>
 </SmellBaseline>


### PR DESCRIPTION
## Summary
- Removed already fixed SpacingBetweenFunctionNameAndOpeningParenthesis issue from baseline.xml
- The spacing issue in NumberToPositions.kt was already corrected in previous changes

## Changes
- config/baseline.xml: Removed SpacingBetweenFunctionNameAndOpeningParenthesis entry

## Test plan
- [x] Run detekt to verify no new violations
- [x] Verify CI passes

🤖 Generated with [Claude Code](https://claude.ai/code)