### PR TITLE
chore: bump version to 0.5.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,7 @@ dependencies {
 }
 
 group = "com.github.sanemat"
-version = "0.5.0" // Use git tags for versioning
+version = "0.5.1" // Use git tags for versioning
 
 publishing {
     publications {

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+<a name="0.5.1"></a>
+## 0.5.1 (2025-07-19)
+
+- Code quality improvements and formatting fixes
+- Internal implementation optimizations
+- Updated dependencies (Kotlin 2.2.0, Gradle 8.14.3)
+- Added detekt linter for code quality
+
 <a name="0.5.0"></a>
 ## 0.5.0 (2024-03-20)
 


### PR DESCRIPTION
## Summary
- Bump version from 0.5.0 to 0.5.1
- Update changelog with code quality improvements and dependency updates

## Changes
- Updated `build.gradle.kts` version to 0.5.1
- Added changelog entry documenting recent improvements:
  - Code quality improvements and formatting fixes
  - Internal implementation optimizations  
  - Updated dependencies (Kotlin 2.2.0, Gradle 8.14.3)
  - Added detekt linter for code quality

## Test plan
- [x] Verify build passes
- [x] Confirm version number is correct in build output

🤖 Generated with [Claude Code](https://claude.ai/code)